### PR TITLE
feat: update identity model validation error messages for translations

### DIFF
--- a/src/GlucoPilot.Api/Middleware/ExceptionMiddleware.cs
+++ b/src/GlucoPilot.Api/Middleware/ExceptionMiddleware.cs
@@ -56,12 +56,15 @@ internal partial class ExceptionMiddleware : IMiddleware
                     break;
                 case NotFoundException:
                     context.Response.StatusCode = StatusCodes.Status404NotFound;
+                    messages.Add(e.Message);
                     break;
                 case UnauthorizedException:
                     context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                    messages.Add(e.Message);
                     break;
                 case ForbiddenException:
                     context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                    messages.Add(e.Message);
                     break;
                 default:
                     context.Response.StatusCode = StatusCodes.Status500InternalServerError;

--- a/src/GlucoPilot.Identity/Models/LoginRequest.cs
+++ b/src/GlucoPilot.Identity/Models/LoginRequest.cs
@@ -11,8 +11,8 @@ public sealed record LoginRequest
     {
         public Validator()
         {
-            RuleFor(x => x.Email).NotEmpty().EmailAddress();
-            RuleFor(x => x.Password).NotEmpty();
+            RuleFor(x => x.Email).NotEmpty().WithMessage("EMAIL_REQUIRED").EmailAddress().WithMessage("EMAIL_INVALID");
+            RuleFor(x => x.Password).NotEmpty().WithMessage("PASSWORD_REQUIRED");
         }
     }
 }

--- a/src/GlucoPilot.Identity/Models/RegisterRequest.cs
+++ b/src/GlucoPilot.Identity/Models/RegisterRequest.cs
@@ -6,18 +6,13 @@ namespace GlucoPilot.Identity.Models;
 
 public sealed record RegisterRequest
 {
-    [Required]
-    [EmailAddress]
-    public required string Email { get; init; }
+    [Required] [EmailAddress] public required string Email { get; init; }
 
-    [Required]
-    public required string Password { get; init; }
+    [Required] public required string Password { get; init; }
 
-    [Required]
-    public required string ConfirmPassword { get; init; }
+    [Required] public required string ConfirmPassword { get; init; }
 
-    [Required]
-    public bool AcceptedTerms { get; init; }
+    [Required] public bool AcceptedTerms { get; init; }
 
     public Guid? PatientId { get; init; }
 
@@ -25,10 +20,12 @@ public sealed record RegisterRequest
     {
         public Validator()
         {
-            RuleFor(x => x.Email).NotEmpty().EmailAddress();
-            RuleFor(x => x.Password).NotEmpty().MinimumLength(6);
-            RuleFor(x => x.ConfirmPassword).NotEmpty().Equal(x => x.Password);
-            RuleFor(x => x.AcceptedTerms).Equal(true);
+            RuleFor(x => x.Email).NotEmpty().WithMessage("EMAIL_REQUIRED").EmailAddress().WithMessage("EMAIL_INVALID");
+            RuleFor(x => x.Password).NotEmpty().WithMessage("PASSWORD_REQUIRED").MinimumLength(6)
+                .WithMessage("PASSWORD_MIN_LENGTH");
+            RuleFor(x => x.ConfirmPassword).NotEmpty().WithMessage("CONFIRM_PASSWORD_REQUIRED").Equal(x => x.Password)
+                .WithMessage("PASSWORD_CONFIRM_NOT_MATCH");
+            RuleFor(x => x.AcceptedTerms).Equal(true).WithMessage("TERMS_NOT_ACCEPTED");
         }
     }
 }


### PR DESCRIPTION
Enable translation of error messages client side by returning translation keys instead of default validation messages.