### PR TITLE
refactor: make login response reference types required

### DIFF
--- a/src/GlucoPilot.LibreLinkClient/Models/LoginResponse.cs
+++ b/src/GlucoPilot.LibreLinkClient/Models/LoginResponse.cs
@@ -11,5 +11,5 @@ public sealed record LoginResponse
     public LoginTerms.LoginTermsStep? Step { get; init; }
 
     [JsonPropertyName("user")]
-    public required UserData UserData { get; init; }
+    public UserData? UserData { get; init; }
 }

--- a/src/GlucoPilot.LibreLinkClient/Models/LoginResponse.cs
+++ b/src/GlucoPilot.LibreLinkClient/Models/LoginResponse.cs
@@ -5,11 +5,11 @@ namespace GlucoPilot.LibreLinkClient.Models;
 public sealed record LoginResponse
 {
     [JsonPropertyName("authTicket")]
-    public AuthTicket AuthTicket { get; init; }
+    public required AuthTicket AuthTicket { get; init; }
 
     [JsonPropertyName("step")]
     public LoginTerms.LoginTermsStep? Step { get; init; }
 
     [JsonPropertyName("user")]
-    public UserData UserData { get; init; }
+    public required UserData UserData { get; init; }
 }


### PR DESCRIPTION
- AuthTicket should never be null
- User data can be null as it's not currently used