### PR TITLE
fix: Fix search in meals endpoint

### DIFF
--- a/src/GlucoPilot.Api/Endpoints/Meals/List/Endpoint.cs
+++ b/src/GlucoPilot.Api/Endpoints/Meals/List/Endpoint.cs
@@ -36,7 +36,8 @@ internal static class Endpoint
 
         if (!string.IsNullOrWhiteSpace(request.Search))
         {
-            mealsQuery = mealsQuery.Where(m => m.Name.Contains(request.Search, StringComparison.OrdinalIgnoreCase));
+            var searchLower = request.Search.ToLower();
+            mealsQuery = mealsQuery.Where(m => m.Name.ToLower().Contains(searchLower));
         }
 
         var meals = mealsQuery

--- a/src/GlucoPilot.Api/Endpoints/Meals/List/Endpoint.cs
+++ b/src/GlucoPilot.Api/Endpoints/Meals/List/Endpoint.cs
@@ -36,8 +36,8 @@ internal static class Endpoint
 
         if (!string.IsNullOrWhiteSpace(request.Search))
         {
-            var searchLower = request.Search.ToLower();
-            mealsQuery = mealsQuery.Where(m => m.Name.ToLower().Contains(searchLower));
+            var searchLower = request.Search.ToLowerInvariant();
+            mealsQuery = mealsQuery.Where(m => m.Name.ToLowerInvariant().Contains(searchLower));
         }
 
         var meals = mealsQuery


### PR DESCRIPTION
Entity Framework does not support StringComparison in .Contains when converting to query. So set string to lowercase before adding to query. 