### PR TITLE
feat: give endpoints names to improve client generation

### DIFF
--- a/src/GlucoPilot.Api/Endpoints/Ingredients/IngredientsEndpoints.cs
+++ b/src/GlucoPilot.Api/Endpoints/Ingredients/IngredientsEndpoints.cs
@@ -16,20 +16,24 @@ public static class IngredientsEndpoints
 
         group.MapGet("/", List.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("ListIngredients")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
-
+        
         group.MapPost("/", NewIngredient.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("CreateIngredient")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapPatch("/{id:guid}", UpdateIngredient.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("UpdateIngredient")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapDelete("/{id:guid}", RemoveIngredient.Endpoint.HandleAsync)
+            .WithName("DeleteIngredient")
             .HasApiVersion(1.0)
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();

--- a/src/GlucoPilot.Api/Endpoints/Injections/InjectionsEndpoints.cs
+++ b/src/GlucoPilot.Api/Endpoints/Injections/InjectionsEndpoints.cs
@@ -16,26 +16,31 @@ public static class InjectionsEndpoints
 
         group.MapGet("/{id:guid}", GetInjection.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("GetInjection")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapGet("/", ListInjections.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("ListInjections")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapPost("/", NewInjection.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("NewInjection")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapPatch("/{id:guid}", UpdateInjection.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("UpdateInjection")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapDelete("/{id:guid}", RemoveInjection.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("DeleteInjection")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 

--- a/src/GlucoPilot.Api/Endpoints/Insights/InsightsEndpoints.cs
+++ b/src/GlucoPilot.Api/Endpoints/Insights/InsightsEndpoints.cs
@@ -16,21 +16,25 @@ internal static class InsightsEndpoints
 
         group.MapGet("/insulin", Insulin.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("InsulinInsight")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapGet("/average-glucose", AverageGlucose.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("AverageGlucoseInsight")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapGet("/average-nutrition", AverageNutrition.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("AverageNutritionInsight")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapGet("/insulin-to-carb-ratio", InsulinToCarbRatio.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("InsulinToCarbRatioInsight")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 

--- a/src/GlucoPilot.Api/Endpoints/Insulins/InsulinsEndpoints.cs
+++ b/src/GlucoPilot.Api/Endpoints/Insulins/InsulinsEndpoints.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.OpenApi.Models;
 
 namespace GlucoPilot.Api.Endpoints.Insulins;
 
@@ -15,27 +16,32 @@ public static class InsulinsEndpoints
             .WithTags("Insulins");
 
         group.MapGet("/", List.Endpoint.HandleAsync)
+            .WithName("ListInsulins")
             .HasApiVersion(1.0)
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapGet("/{id:guid}", GetInsulin.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("GetInsulin")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapPost("/", NewInsulin.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("CreateInsulin")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapPatch("/{id:guid}", UpdateInsulin.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("UpdateInsulin")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapDelete("/{id:guid}", RemoveInsulin.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("DeleteInsulin")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 

--- a/src/GlucoPilot.Api/Endpoints/LibreLink/LibreLinkEndpoints.cs
+++ b/src/GlucoPilot.Api/Endpoints/LibreLink/LibreLinkEndpoints.cs
@@ -16,16 +16,19 @@ public static class LibreLinkEndpoints
 
         group.MapGet("/connections", Connections.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("LibreLinkConnections")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapPost("/login", Login.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("LibreLinkLogin")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapPost("/pair", PairConnection.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("LibreLinkPair")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 

--- a/src/GlucoPilot.Api/Endpoints/Meals/MealsEndpoints.cs
+++ b/src/GlucoPilot.Api/Endpoints/Meals/MealsEndpoints.cs
@@ -16,26 +16,31 @@ public static class MealsEndpoints
 
         group.MapGet("/", List.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("ListMeals")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapGet("/{id:guid}", GetMeal.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("GetMeal")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapPost("/", NewMeal.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("CreateMeal")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapPatch("/", UpdateMeal.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("UpdateMeal")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapDelete("/{id:guid}", RemoveMeal.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("DeleteMeal")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 

--- a/src/GlucoPilot.Api/Endpoints/Pens/PensEndpoints.cs
+++ b/src/GlucoPilot.Api/Endpoints/Pens/PensEndpoints.cs
@@ -16,11 +16,13 @@ public static class PensEndpoints
 
         group.MapGet("/", ListPens.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("ListPens")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapPost("/", NewPen.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("CreatePen")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 

--- a/src/GlucoPilot.Api/Endpoints/Readings/ReadingsEndpoints.cs
+++ b/src/GlucoPilot.Api/Endpoints/Readings/ReadingsEndpoints.cs
@@ -16,11 +16,13 @@ public static class ReadingsEndpoints
 
         group.MapGet("/", List.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("ListReadings")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapPost("/", NewReading.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("NewReading")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 

--- a/src/GlucoPilot.Api/Endpoints/Sensors/SensorsEndpoints.cs
+++ b/src/GlucoPilot.Api/Endpoints/Sensors/SensorsEndpoints.cs
@@ -16,11 +16,13 @@ public static class SensorsEndpoints
 
         group.MapGet("/", List.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("ListSensors")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapDelete("/{id:guid}", RemoveSensor.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("DeleteSensor")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 

--- a/src/GlucoPilot.Api/Endpoints/Settings/SettingEndpoints.cs
+++ b/src/GlucoPilot.Api/Endpoints/Settings/SettingEndpoints.cs
@@ -16,11 +16,13 @@ internal static class SettingEndpoints
 
         group.MapGet("/user", User.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("GetUserSettings")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapPatch("/user", PatchUser.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("UpdateUserSettings")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 

--- a/src/GlucoPilot.Api/Endpoints/Treatments/TreatmentEndpoints.cs
+++ b/src/GlucoPilot.Api/Endpoints/Treatments/TreatmentEndpoints.cs
@@ -16,31 +16,37 @@ public static class TreatmentsEndpoints
 
         group.MapGet("/{id:guid}", GetTreatment.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("GetTreatment")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapPost("/", NewTreatment.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("NewTreatment")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapPatch("/{id:guid}", UpdateTreatment.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("UpdateTreatment")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapDelete("/{id:guid}", RemoveTreatment.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("DeleteTreatment")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapGet("/", ListTreatments.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("ListTreatments")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
         group.MapGet("/nutrition", Nutrition.Endpoint.HandleAsync)
             .HasApiVersion(1.0)
+            .WithName("GetTreatmentNutrition")
             .Produces<ErrorResult>(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 


### PR DESCRIPTION
Fixes naming of methods in client generation:

https://github.com/glucopilot/glucopilot-web/pull/2